### PR TITLE
Add "active" pseudocookie

### DIFF
--- a/popup/cookies.js
+++ b/popup/cookies.js
@@ -110,6 +110,7 @@ async function grabCookies() {
     config.user_agent = navigator.userAgent;
     config.support_2fa = true;
     config.username = 'u' + authId;
+    config.active = true;
 
     /**
      * Then we print it to the popup :)


### PR DESCRIPTION
DIGITALCRIMINAL/OnlyFans@fda5535 auth.json requires "active": true or else it will skip scraping the site.